### PR TITLE
feat(backend): Implementação do endpoint de atualização de atletas (PUT)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/backend/src/main/java/com/healthyway/api/controller/AthleteController.java
+++ b/backend/src/main/java/com/healthyway/api/controller/AthleteController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
@@ -31,5 +32,27 @@ public class AthleteController {
         return service.findById(id)
                 .map(record -> ResponseEntity.ok().body(record)) // Se achou, retorna 200 OK com o atleta
                 .orElse(ResponseEntity.notFound().build()); // Se não achou, retorna 404 Not Found
+    }
+
+    @PostMapping // Responde a POST /athletes
+    public ResponseEntity<Athlete> criar(@RequestBody Athlete athlete) {
+        // @RequestBody: Pega o JSON do corpo da requisição e transforma em Objeto Java
+        Athlete novoAtleta = service.create(athlete);
+        // Retorna status 201 Created e o objeto criado
+        return ResponseEntity.status(HttpStatus.CREATED).body(novoAtleta);
+    }
+
+    @PutMapping("/{id}") // Responde a PUT /athletes/id
+    public ResponseEntity<Athlete> atualizar(@PathVariable Long id, @RequestBody Athlete athlete) {
+        
+        Athlete atletaAtualizado = service.update(id, athlete);
+        
+        return ResponseEntity.ok(atletaAtualizado);
+    }
+
+    @DeleteMapping("/{id}") // Responde a DELETE /athletes/id
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build(); // Retorna código 204 (Sucesso sem conteúdo)
     }
 }

--- a/backend/src/main/java/com/healthyway/api/service/AthleteService.java
+++ b/backend/src/main/java/com/healthyway/api/service/AthleteService.java
@@ -27,4 +27,36 @@ public class AthleteService {
         // O 'Optional' é uma caixa que pode ter um Atleta ou estar vazia (se não achar)
         return repository.findById(id); 
     }
+
+    // 5. Método para deletar um atleta pelo ID
+    public void delete(Long id) {
+        if (repository.existsById(id)) {
+            repository.deleteById(id);
+        } else {
+            // Opcional: Lançar erro se não achar, mas por enquanto vamos só ignorar
+            throw new RuntimeException("Atleta não encontrado para deleção");
+        }
+    }
+
+    // 6. Método para adicionar um atleta novo
+    public Athlete create(Athlete athlete) {
+        // O método .save() do JPA serve tanto para criar quanto para atualizar.
+        // Se o ID for nulo, ele cria. Se tiver ID, ele atualiza.
+        return repository.save(athlete);
+    }
+
+    // 7. Método para atualizar os dados de um atleta
+    public Athlete update(Long id, Athlete atletaComNovosDados) {
+        // Verifica se existe antes de tentar atualizar
+        if (!repository.existsById(id)) {
+            throw new RuntimeException("Atleta não encontrado para atualização");
+        }
+        // Garante que o ID do objeto é o mesmo que passamos na URL
+        // (Isso evita que alguém tente mudar o ID do atleta por acidente)
+        atletaComNovosDados.setId(id);
+
+        // Salva (Como o ID já existe no banco, o JPA entende que é um UPDATE)
+        return repository.save(atletaComNovosDados);
+    }
+
 }


### PR DESCRIPTION
## 📝 Descrição
Adiciona a funcionalidade de atualizar (Update) os dados de um atleta existente na API.

### O que foi feito:
* **Service**: Implementação do método `update` em `AthleteService`, que verifica se o ID existe antes de salvar as alterações.
* **Controller**: Criação do endpoint `@PutMapping("/{id}")` em `AthleteController`.
* **Segurança**: Garante que o ID do objeto salvo seja o mesmo da URL para evitar inconsistências.

## 🔗 Issue Relacionada

Closes #33 

## ✅ Checklist de Revisão

- [X] Meu código segue as diretrizes de estilo deste projeto.
- [X] Eu realizei uma auto-revisão do meu próprio código.
- [X] Eu comentei meu código em áreas de difícil compreensão(Se Aplicável).
- [ ] Eu fiz as alterações correspondentes na documentação(Se Aplicável).
- [X] Meus testes foram atualizados para refletir minhas mudanças(Se Aplicável).
- [X] Todos os testes novos e existentes passam com sucesso(Se Aplicável).

## 🧪 Como Testar (se aplicável)

1. Rodar o backend (`mvnw spring-boot:run`).
2. Usar o Insomnia/Postman.
3. Fazer uma requisição `PUT` para `http://localhost:8080/athletes/{id}` com o JSON dos novos dados.
4. O retorno deve ser `200 OK` com os dados atualizados.

## 📌 Notas Adicionais (se aplicável)
Não há como testar pela interface pois não há componentes que ativem os serviços.